### PR TITLE
Add Go Gin backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # peconote
+
+This repository contains a minimal backend API skeleton built with Go. It adopts the Gin web framework, Gorm ORM, and follows a Clean Architecture with Domain-Driven Design approach.
+
+## Run
+
+```bash
+go run ./cmd/api
+```
+
+## Structure
+
+- `cmd/api` - Application entry point
+- `internal/domain` - Entity and repository interfaces
+- `internal/usecase` - Business logic
+- `internal/interfaces` - HTTP controllers
+- `internal/infrastructure` - Database, router, and repository implementations
+

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+
+	"github.com/peconote/peconote/internal/infrastructure/db"
+	"github.com/peconote/peconote/internal/infrastructure/router"
+)
+
+func main() {
+	d, err := db.NewDB()
+	if err != nil {
+		log.Fatalf("failed to connect database: %v", err)
+	}
+
+	r := router.NewRouter(d)
+	if err := r.Run(); err != nil {
+		log.Fatalf("failed to run server: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/peconote/peconote
+
+go 1.20
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    gorm.io/driver/sqlite v1.5.5
+    gorm.io/gorm v1.25.5
+)
+

--- a/internal/domain/model/user.go
+++ b/internal/domain/model/user.go
@@ -1,0 +1,7 @@
+package model
+
+type User struct {
+	ID    uint   `gorm:"primaryKey"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -1,0 +1,8 @@
+package repository
+
+import "github.com/peconote/peconote/internal/domain/model"
+
+type UserRepository interface {
+	FindAll() ([]model.User, error)
+	Create(user *model.User) error
+}

--- a/internal/infrastructure/db/db.go
+++ b/internal/infrastructure/db/db.go
@@ -1,0 +1,10 @@
+package db
+
+import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func NewDB() (*gorm.DB, error) {
+	return gorm.Open(sqlite.Open("app.db"), &gorm.Config{})
+}

--- a/internal/infrastructure/persistence/user_repository.go
+++ b/internal/infrastructure/persistence/user_repository.go
@@ -1,0 +1,27 @@
+package persistence
+
+import (
+	"github.com/peconote/peconote/internal/domain/model"
+	domainRepository "github.com/peconote/peconote/internal/domain/repository"
+	"gorm.io/gorm"
+)
+
+type userRepository struct {
+	db *gorm.DB
+}
+
+func NewUserRepository(db *gorm.DB) domainRepository.UserRepository {
+	return &userRepository{db: db}
+}
+
+func (r *userRepository) FindAll() ([]model.User, error) {
+	var users []model.User
+	if err := r.db.Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func (r *userRepository) Create(user *model.User) error {
+	return r.db.Create(user).Error
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -1,0 +1,23 @@
+package router
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/peconote/peconote/internal/infrastructure/persistence"
+	"github.com/peconote/peconote/internal/interfaces/controller"
+	"github.com/peconote/peconote/internal/usecase"
+)
+
+func NewRouter(db *gorm.DB) *gin.Engine {
+	r := gin.Default()
+
+	userRepo := persistence.NewUserRepository(db)
+	userUsecase := usecase.NewUserUsecase(userRepo)
+	userController := controller.NewUserController(userUsecase)
+
+	r.GET("/users", userController.GetUsers)
+	r.POST("/users", userController.CreateUser)
+
+	return r
+}

--- a/internal/interfaces/controller/user_controller.go
+++ b/internal/interfaces/controller/user_controller.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/peconote/peconote/internal/domain/model"
+	"github.com/peconote/peconote/internal/usecase"
+)
+
+type UserController struct {
+	usecase usecase.UserUsecase
+}
+
+func NewUserController(u usecase.UserUsecase) *UserController {
+	return &UserController{usecase: u}
+}
+
+func (c *UserController) GetUsers(ctx *gin.Context) {
+	users, err := c.usecase.GetUsers()
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, users)
+}
+
+func (c *UserController) CreateUser(ctx *gin.Context) {
+	var user model.User
+	if err := ctx.ShouldBindJSON(&user); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := c.usecase.CreateUser(&user); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusCreated, user)
+}

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -1,0 +1,27 @@
+package usecase
+
+import (
+	"github.com/peconote/peconote/internal/domain/model"
+	"github.com/peconote/peconote/internal/domain/repository"
+)
+
+type UserUsecase interface {
+	GetUsers() ([]model.User, error)
+	CreateUser(user *model.User) error
+}
+
+type userUsecase struct {
+	repo repository.UserRepository
+}
+
+func NewUserUsecase(r repository.UserRepository) UserUsecase {
+	return &userUsecase{repo: r}
+}
+
+func (u *userUsecase) GetUsers() ([]model.User, error) {
+	return u.repo.FindAll()
+}
+
+func (u *userUsecase) CreateUser(user *model.User) error {
+	return u.repo.Create(user)
+}


### PR DESCRIPTION
## Summary
- add minimal Gin/Gorm API skeleton with clean architecture layers
- provide example user entity, repository, usecase, controller, and router
- document project structure and run instructions

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6890c9648508832684f794d611f9b434