### PR TITLE
feat: add memo creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,35 @@ go run ./cmd/api
 - `internal/usecase` - Business logic
 - `internal/interfaces` - HTTP controllers
 - `internal/infrastructure` - Database, router, and repository implementations
+## API
 
+### Create Memo
+
+`POST /api/memos`
+
+Request body:
+
+```json
+{
+  "body": "memo text",
+  "tags": ["tag1", "tag2"]
+}
+```
+
+Example:
+
+```bash
+curl -X POST http://localhost:8080/api/memos \
+  -H "Content-Type: application/json" \
+  -d '{"body":"hello","tags":["sample"]}'
+```
+
+Response:
+
+`201 Created`
+
+```json
+{"id":"<uuid>"}
+```
+
+The `Location` header contains `/api/memos/{id}`.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -8,12 +8,17 @@ import (
 )
 
 func main() {
-	d, err := db.NewDB()
+	gormDB, err := db.NewDB()
 	if err != nil {
 		log.Fatalf("failed to connect database: %v", err)
 	}
 
-	r := router.NewRouter(d)
+	sqlxDB, err := db.NewSqlxDB()
+	if err != nil {
+		log.Fatalf("failed to connect database: %v", err)
+	}
+
+	r := router.NewRouter(gormDB, sqlxDB)
 	if err := r.Run(); err != nil {
 		log.Fatalf("failed to run server: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/peconote/peconote
 go 1.20
 
 require (
-    github.com/gin-gonic/gin v1.9.1
-    gorm.io/driver/sqlite v1.5.5
-    gorm.io/gorm v1.25.5
+        github.com/gin-gonic/gin v1.9.1
+        github.com/google/uuid v1.3.0
+        github.com/jmoiron/sqlx v1.4.0
+        github.com/lib/pq v1.10.9
+        gorm.io/driver/sqlite v1.5.5
+        gorm.io/gorm v1.25.7-0.20240204074919-46816ad31dde
 )
-

--- a/internal/adapter/handler/memo_dto.go
+++ b/internal/adapter/handler/memo_dto.go
@@ -1,0 +1,10 @@
+package handler
+
+type MemoCreateRequest struct {
+	Body string   `json:"body" binding:"required,max=2000"`
+	Tags []string `json:"tags" binding:"max=10"`
+}
+
+type MemoCreateResponse struct {
+	ID string `json:"id"`
+}

--- a/internal/adapter/handler/memo_handler.go
+++ b/internal/adapter/handler/memo_handler.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/peconote/peconote/internal/usecase"
+)
+
+type MemoHandler struct {
+	usecase usecase.MemoUsecase
+}
+
+func NewMemoHandler(u usecase.MemoUsecase) *MemoHandler {
+	return &MemoHandler{usecase: u}
+}
+
+func (h *MemoHandler) CreateMemo(c *gin.Context) {
+	var req MemoCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := h.usecase.CreateMemo(c.Request.Context(), req.Body, req.Tags)
+	if err != nil {
+		if errors.Is(err, usecase.ErrInvalidMemo) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+	c.Header("Location", "/api/memos/"+id.String())
+	c.JSON(http.StatusCreated, MemoCreateResponse{ID: id.String()})
+}

--- a/internal/adapter/handler/memo_handler_test.go
+++ b/internal/adapter/handler/memo_handler_test.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/peconote/peconote/internal/usecase"
+)
+
+type stubMemoUsecase struct {
+	id  uuid.UUID
+	err error
+}
+
+func (s *stubMemoUsecase) CreateMemo(ctx context.Context, body string, tags []string) (uuid.UUID, error) {
+	return s.id, s.err
+}
+
+func TestCreateMemoHandler_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := uuid.New()
+	h := NewMemoHandler(&stubMemoUsecase{id: id})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/memos", bytes.NewBufferString(`{"body":"hi","tags":["t"]}`))
+	h.CreateMemo(c)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/api/memos/"+id.String() {
+		t.Fatalf("expected location header, got %s", loc)
+	}
+}
+
+func TestCreateMemoHandler_UsecaseError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewMemoHandler(&stubMemoUsecase{err: usecase.ErrInvalidMemo})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/memos", bytes.NewBufferString(`{"body":"","tags":[]}`))
+	h.CreateMemo(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", w.Code)
+	}
+}

--- a/internal/adapter/repository/memo_pg.go
+++ b/internal/adapter/repository/memo_pg.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/peconote/peconote/internal/domain"
+	domainRepo "github.com/peconote/peconote/internal/domain/repository"
+)
+
+type memoRepository struct {
+	db *sqlx.DB
+}
+
+func NewMemoRepository(db *sqlx.DB) domainRepo.MemoRepository {
+	return &memoRepository{db: db}
+}
+
+func (r *memoRepository) Create(ctx context.Context, m *domain.Memo) error {
+	query := `INSERT INTO memo (id, body, tags, created_at, updated_at) VALUES (:id, :body, :tags, :created_at, :updated_at)`
+	_, err := r.db.NamedExecContext(ctx, query, map[string]interface{}{
+		"id":         m.ID,
+		"body":       m.Body,
+		"tags":       pq.StringArray(m.Tags),
+		"created_at": m.CreatedAt,
+		"updated_at": m.UpdatedAt,
+	})
+	return err
+}

--- a/internal/domain/memo.go
+++ b/internal/domain/memo.go
@@ -1,0 +1,15 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Memo struct {
+	ID        uuid.UUID
+	Body      string
+	Tags      []string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/domain/repository/memo_repository.go
+++ b/internal/domain/repository/memo_repository.go
@@ -1,0 +1,11 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/peconote/peconote/internal/domain"
+)
+
+type MemoRepository interface {
+	Create(ctx context.Context, m *domain.Memo) error
+}

--- a/internal/infrastructure/db/sqlx.go
+++ b/internal/infrastructure/db/sqlx.go
@@ -1,0 +1,16 @@
+package db
+
+import (
+	"os"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+)
+
+func NewSqlxDB() (*sqlx.DB, error) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+	}
+	return sqlx.Open("postgres", dsn)
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -1,23 +1,52 @@
 package router
 
 import (
+	"encoding/json"
 	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
 	"gorm.io/gorm"
 
+	adapterhandler "github.com/peconote/peconote/internal/adapter/handler"
+	adapterrepo "github.com/peconote/peconote/internal/adapter/repository"
 	"github.com/peconote/peconote/internal/infrastructure/persistence"
 	"github.com/peconote/peconote/internal/interfaces/controller"
 	"github.com/peconote/peconote/internal/usecase"
 )
 
-func NewRouter(db *gorm.DB) *gin.Engine {
-	r := gin.Default()
+func NewRouter(gormDB *gorm.DB, sqlxDB *sqlx.DB) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Recovery(), jsonLogger())
 
-	userRepo := persistence.NewUserRepository(db)
+	userRepo := persistence.NewUserRepository(gormDB)
 	userUsecase := usecase.NewUserUsecase(userRepo)
 	userController := controller.NewUserController(userUsecase)
 
 	r.GET("/users", userController.GetUsers)
 	r.POST("/users", userController.CreateUser)
 
+	memoRepo := adapterrepo.NewMemoRepository(sqlxDB)
+	memoUsecase := usecase.NewMemoUsecase(memoRepo)
+	memoHandler := adapterhandler.NewMemoHandler(memoUsecase)
+
+	r.POST("/api/memos", memoHandler.CreateMemo)
+
 	return r
+}
+
+func jsonLogger() gin.HandlerFunc {
+	return gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
+		m := map[string]interface{}{
+			"method":     param.Method,
+			"path":       param.Path,
+			"status":     param.StatusCode,
+			"latency_ms": param.Latency.Milliseconds(),
+		}
+		if v := param.Request.Context().Value("trace_id"); v != nil {
+			if s, ok := v.(string); ok {
+				m["trace_id"] = s
+			}
+		}
+		b, _ := json.Marshal(m)
+		return string(b) + "\n"
+	})
 }

--- a/internal/usecase/memo_interactor.go
+++ b/internal/usecase/memo_interactor.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/peconote/peconote/internal/domain"
+	"github.com/peconote/peconote/internal/domain/repository"
+)
+
+var ErrInvalidMemo = errors.New("invalid memo")
+
+type MemoUsecase interface {
+	CreateMemo(ctx context.Context, body string, tags []string) (uuid.UUID, error)
+}
+
+type memoUsecase struct {
+	repo repository.MemoRepository
+}
+
+func NewMemoUsecase(r repository.MemoRepository) MemoUsecase {
+	return &memoUsecase{repo: r}
+}
+
+func (u *memoUsecase) CreateMemo(ctx context.Context, body string, tags []string) (uuid.UUID, error) {
+	if strings.TrimSpace(body) == "" || len(body) > 2000 {
+		return uuid.Nil, ErrInvalidMemo
+	}
+	if len(tags) > 10 {
+		return uuid.Nil, ErrInvalidMemo
+	}
+	for _, t := range tags {
+		if l := len(t); l < 1 || l > 30 {
+			return uuid.Nil, ErrInvalidMemo
+		}
+	}
+	id := uuid.New()
+	now := time.Now().UTC()
+	memo := &domain.Memo{
+		ID:        id,
+		Body:      body,
+		Tags:      tags,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := u.repo.Create(ctx, memo); err != nil {
+		return uuid.Nil, err
+	}
+	return id, nil
+}

--- a/internal/usecase/memo_interactor_test.go
+++ b/internal/usecase/memo_interactor_test.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/peconote/peconote/internal/domain"
+)
+
+type mockMemoRepository struct {
+	memo *domain.Memo
+	err  error
+}
+
+func (m *mockMemoRepository) Create(ctx context.Context, mem *domain.Memo) error {
+	m.memo = mem
+	return m.err
+}
+
+func TestCreateMemo_Success(t *testing.T) {
+	repo := &mockMemoRepository{}
+	u := NewMemoUsecase(repo)
+
+	id, err := u.CreateMemo(context.Background(), "hello", []string{"tag"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == uuid.Nil {
+		t.Fatalf("expected valid id")
+	}
+	if repo.memo == nil || repo.memo.Body != "hello" {
+		t.Fatalf("memo not saved")
+	}
+}
+
+func TestCreateMemo_Validation(t *testing.T) {
+	repo := &mockMemoRepository{}
+	u := NewMemoUsecase(repo)
+
+	_, err := u.CreateMemo(context.Background(), "", nil)
+	if !errors.Is(err, ErrInvalidMemo) {
+		t.Fatalf("expected validation error")
+	}
+}

--- a/migrations/0001_create_memo.sql
+++ b/migrations/0001_create_memo.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS memo (
+    id UUID PRIMARY KEY,
+    body TEXT NOT NULL,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_memo_tags ON memo USING GIN (tags);


### PR DESCRIPTION
## Summary
- add memo entity, repository, use case, and handler for POST /api/memos
- log requests in JSON format and add SQL migrations
- document memo creation endpoint in README

## Testing
- `go test ./...` *(fails: missing go.sum entry for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6890cc1c3d788326b458632a30be1a8a