### PR TITLE
Implement paginated memo listing endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.20
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o server ./cmd/api
+CMD ["./server"]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,28 @@ Response:
 ```
 
 The `Location` header contains `/api/memos/{id}`.
+
+### List Memos
+
+`GET /api/memos`
+
+Query parameters:
+
+- `page` (default `1`)
+- `page_size` (default `20`, max `100`)
+- `tag` (optional)
+
+Example:
+
+```bash
+curl "http://localhost:8080/api/memos?page=2&page_size=10"
+```
+
+Response:
+
+```json
+{
+  "items": [{"id": "<uuid>", "body": "memo", "tags": ["tag"], "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"}],
+  "pagination": {"page": 2, "page_size": 10, "total_pages": 5, "total_count": 50}
+}
+```

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+gorm.io/driver/sqlite v1.5.5/go.mod h1:6NgQ7sQWAIFsPrJJl1lSNSu2TABh0ZZ/zm5fosATavE=
+gorm.io/gorm v1.25.7-0.20240204074919-46816ad31dde/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=

--- a/internal/adapter/handler/memo_dto.go
+++ b/internal/adapter/handler/memo_dto.go
@@ -1,5 +1,11 @@
 package handler
 
+import (
+	"time"
+
+	"github.com/peconote/peconote/internal/domain/model"
+)
+
 type MemoCreateRequest struct {
 	Body string   `json:"body" binding:"required,max=2000"`
 	Tags []string `json:"tags" binding:"max=10"`
@@ -7,4 +13,17 @@ type MemoCreateRequest struct {
 
 type MemoCreateResponse struct {
 	ID string `json:"id"`
+}
+
+type MemoItem struct {
+	ID        string    `json:"id"`
+	Body      string    `json:"body"`
+	Tags      []string  `json:"tags"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type MemoListResponse struct {
+	Items      []MemoItem       `json:"items"`
+	Pagination model.Pagination `json:"pagination"`
 }

--- a/internal/adapter/handler/memo_handler.go
+++ b/internal/adapter/handler/memo_handler.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/peconote/peconote/internal/adapter/handler/util"
 	"github.com/peconote/peconote/internal/usecase"
 )
 
@@ -34,4 +36,53 @@ func (h *MemoHandler) CreateMemo(c *gin.Context) {
 	}
 	c.Header("Location", "/api/memos/"+id.String())
 	c.JSON(http.StatusCreated, MemoCreateResponse{ID: id.String()})
+}
+
+func (h *MemoHandler) ListMemos(c *gin.Context) {
+	pageStr := c.DefaultQuery("page", "1")
+	page, err := strconv.Atoi(pageStr)
+	if err != nil || page < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page"})
+		return
+	}
+	sizeStr := c.DefaultQuery("page_size", "20")
+	pageSize, err := strconv.Atoi(sizeStr)
+	if err != nil || pageSize < 1 || pageSize > 100 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page_size"})
+		return
+	}
+	var tagPtr *string
+	if tag, ok := c.GetQuery("tag"); ok {
+		if tag == "" || len(tag) > 30 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid tag"})
+			return
+		}
+		tagPtr = &tag
+	}
+
+	items, pagination, err := h.usecase.ListMemos(c.Request.Context(), page, pageSize, tagPtr)
+	if err != nil {
+		if errors.Is(err, usecase.ErrInvalidMemoQuery) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+
+	resItems := make([]MemoItem, len(items))
+	for i, m := range items {
+		resItems[i] = MemoItem{
+			ID:        m.ID.String(),
+			Body:      m.Body,
+			Tags:      m.Tags,
+			CreatedAt: m.CreatedAt,
+			UpdatedAt: m.UpdatedAt,
+		}
+	}
+	resp := MemoListResponse{Items: resItems, Pagination: *pagination}
+	if link := util.BuildLinkHeader("/api/memos", resp.Pagination, tagPtr); link != "" {
+		c.Header("Link", link)
+	}
+	c.JSON(http.StatusOK, resp)
 }

--- a/internal/adapter/handler/memo_handler_e2e_test.go
+++ b/internal/adapter/handler/memo_handler_e2e_test.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/peconote/peconote/internal/domain"
+	"github.com/peconote/peconote/internal/usecase"
+)
+
+type memoryMemoRepo struct {
+	memos []*domain.Memo
+}
+
+func (m *memoryMemoRepo) Create(ctx context.Context, memo *domain.Memo) error {
+	m.memos = append(m.memos, memo)
+	return nil
+}
+
+func (m *memoryMemoRepo) List(ctx context.Context, tag *string, limit, offset int) ([]*domain.Memo, int, error) {
+	filtered := make([]*domain.Memo, 0, len(m.memos))
+	for _, me := range m.memos {
+		if tag != nil {
+			ok := false
+			for _, t := range me.Tags {
+				if t == *tag {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+		}
+		filtered = append(filtered, me)
+	}
+	total := len(filtered)
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	if offset > total {
+		return []*domain.Memo{}, total, nil
+	}
+	return filtered[offset:end], total, nil
+}
+
+func TestListMemos_E2E(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &memoryMemoRepo{}
+	now := time.Now()
+	for i := 0; i < 30; i++ {
+		repo.memos = append(repo.memos, &domain.Memo{
+			ID:        uuid.New(),
+			Body:      fmt.Sprintf("memo %d", i),
+			Tags:      []string{"t"},
+			CreatedAt: now.Add(-time.Duration(i) * time.Minute),
+			UpdatedAt: now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	u := usecase.NewMemoUsecase(repo)
+	h := NewMemoHandler(u)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/memos?page=2&page_size=10", nil)
+	h.ListMemos(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	if link := w.Header().Get("Link"); link == "" {
+		t.Fatalf("expected Link header")
+	}
+	var resp MemoListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(resp.Items) != 10 {
+		t.Fatalf("expected 10 items")
+	}
+	if !resp.Items[0].CreatedAt.After(resp.Items[9].CreatedAt) {
+		t.Fatalf("items not sorted")
+	}
+}

--- a/internal/adapter/handler/memo_handler_test.go
+++ b/internal/adapter/handler/memo_handler_test.go
@@ -3,22 +3,32 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/peconote/peconote/internal/domain"
+	"github.com/peconote/peconote/internal/domain/model"
 	"github.com/peconote/peconote/internal/usecase"
 )
 
 type stubMemoUsecase struct {
-	id  uuid.UUID
-	err error
+	id         uuid.UUID
+	err        error
+	items      []*domain.Memo
+	pagination *model.Pagination
 }
 
 func (s *stubMemoUsecase) CreateMemo(ctx context.Context, body string, tags []string) (uuid.UUID, error) {
 	return s.id, s.err
+}
+
+func (s *stubMemoUsecase) ListMemos(ctx context.Context, page, pageSize int, tag *string) ([]*domain.Memo, *model.Pagination, error) {
+	return s.items, s.pagination, s.err
 }
 
 func TestCreateMemoHandler_Success(t *testing.T) {
@@ -44,6 +54,45 @@ func TestCreateMemoHandler_UsecaseError(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/api/memos", bytes.NewBufferString(`{"body":"","tags":[]}`))
 	h.CreateMemo(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", w.Code)
+	}
+}
+
+func TestListMemosHandler_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	now := time.Now()
+	items := []*domain.Memo{
+		{ID: uuid.New(), Body: "a", Tags: []string{"t"}, CreatedAt: now, UpdatedAt: now},
+	}
+	stub := &stubMemoUsecase{items: items, pagination: &model.Pagination{Page: 1, PageSize: 1, TotalPages: 2, TotalCount: 2}}
+	h := NewMemoHandler(stub)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/memos?page=1&page_size=1", nil)
+	h.ListMemos(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	if link := w.Header().Get("Link"); link != "</api/memos?page=2&page_size=1>; rel=\"next\"" {
+		t.Fatalf("unexpected Link header: %s", link)
+	}
+	var resp MemoListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item")
+	}
+}
+
+func TestListMemosHandler_BadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewMemoHandler(&stubMemoUsecase{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/memos?page=0", nil)
+	h.ListMemos(c)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 got %d", w.Code)
 	}

--- a/internal/adapter/handler/util/link.go
+++ b/internal/adapter/handler/util/link.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/peconote/peconote/internal/domain/model"
+)
+
+func BuildLinkHeader(base string, p model.Pagination, tag *string) string {
+	var links []string
+	tagParam := ""
+	if tag != nil {
+		tagParam = "&tag=" + url.QueryEscape(*tag)
+	}
+	if p.Page < p.TotalPages {
+		next := fmt.Sprintf("%s?page=%d&page_size=%d%s", base, p.Page+1, p.PageSize, tagParam)
+		links = append(links, fmt.Sprintf("<%s>; rel=\"next\"", next))
+	}
+	if p.Page > 1 {
+		prev := fmt.Sprintf("%s?page=%d&page_size=%d%s", base, p.Page-1, p.PageSize, tagParam)
+		links = append(links, fmt.Sprintf("<%s>; rel=\"prev\"", prev))
+	}
+	return strings.Join(links, ", ")
+}

--- a/internal/domain/model/pagination.go
+++ b/internal/domain/model/pagination.go
@@ -1,0 +1,8 @@
+package model
+
+type Pagination struct {
+	Page       int `json:"page"`
+	PageSize   int `json:"page_size"`
+	TotalPages int `json:"total_pages"`
+	TotalCount int `json:"total_count"`
+}

--- a/internal/domain/repository/memo_repository.go
+++ b/internal/domain/repository/memo_repository.go
@@ -8,4 +8,5 @@ import (
 
 type MemoRepository interface {
 	Create(ctx context.Context, m *domain.Memo) error
+	List(ctx context.Context, tag *string, limit, offset int) ([]*domain.Memo, int, error)
 }

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -29,6 +29,7 @@ func NewRouter(gormDB *gorm.DB, sqlxDB *sqlx.DB) *gin.Engine {
 	memoHandler := adapterhandler.NewMemoHandler(memoUsecase)
 
 	r.POST("/api/memos", memoHandler.CreateMemo)
+	r.GET("/api/memos", memoHandler.ListMemos)
 
 	return r
 }
@@ -40,6 +41,16 @@ func jsonLogger() gin.HandlerFunc {
 			"path":       param.Path,
 			"status":     param.StatusCode,
 			"latency_ms": param.Latency.Milliseconds(),
+		}
+		q := param.Request.URL.Query()
+		if v := q.Get("page"); v != "" {
+			m["page"] = v
+		}
+		if v := q.Get("page_size"); v != "" {
+			m["page_size"] = v
+		}
+		if v := q.Get("tag"); v != "" {
+			m["tag"] = v
 		}
 		if v := param.Request.Context().Value("trace_id"); v != nil {
 			if s, ok := v.(string); ok {

--- a/internal/usecase/memo_interactor_test.go
+++ b/internal/usecase/memo_interactor_test.go
@@ -4,19 +4,26 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/peconote/peconote/internal/domain"
 )
 
 type mockMemoRepository struct {
-	memo *domain.Memo
-	err  error
+	memo      *domain.Memo
+	err       error
+	listItems []*domain.Memo
+	total     int
 }
 
 func (m *mockMemoRepository) Create(ctx context.Context, mem *domain.Memo) error {
 	m.memo = mem
 	return m.err
+}
+
+func (m *mockMemoRepository) List(ctx context.Context, tag *string, limit, offset int) ([]*domain.Memo, int, error) {
+	return m.listItems, m.total, m.err
 }
 
 func TestCreateMemo_Success(t *testing.T) {
@@ -41,6 +48,35 @@ func TestCreateMemo_Validation(t *testing.T) {
 
 	_, err := u.CreateMemo(context.Background(), "", nil)
 	if !errors.Is(err, ErrInvalidMemo) {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestListMemos_Success(t *testing.T) {
+	now := time.Now()
+	repo := &mockMemoRepository{listItems: []*domain.Memo{{ID: uuid.New(), Body: "b", CreatedAt: now, UpdatedAt: now}}, total: 1}
+	u := NewMemoUsecase(repo)
+	items, p, err := u.ListMemos(context.Background(), 1, 20, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || p.TotalCount != 1 {
+		t.Fatalf("unexpected result")
+	}
+}
+
+func TestListMemos_Validation(t *testing.T) {
+	repo := &mockMemoRepository{}
+	u := NewMemoUsecase(repo)
+	if _, _, err := u.ListMemos(context.Background(), 1, 101, nil); !errors.Is(err, ErrInvalidMemoQuery) {
+		t.Fatalf("expected validation error")
+	}
+	tag := ""
+	if _, _, err := u.ListMemos(context.Background(), 1, 10, &tag); !errors.Is(err, ErrInvalidMemoQuery) {
+		t.Fatalf("expected validation error")
+	}
+	longTag := "1234567890123456789012345678901"
+	if _, _, err := u.ListMemos(context.Background(), 1, 10, &longTag); !errors.Is(err, ErrInvalidMemoQuery) {
 		t.Fatalf("expected validation error")
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,103 @@
+openapi: 3.0.0
+info:
+  title: PecoNote API
+  version: 1.0.0
+paths:
+  /api/memos:
+    get:
+      summary: List memos
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - in: query
+          name: tag
+          schema:
+            type: string
+            maxLength: 30
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoListResponse'
+    post:
+      summary: Create memo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemoCreateRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoCreateResponse'
+components:
+  schemas:
+    MemoCreateRequest:
+      type: object
+      properties:
+        body:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+      required: [body]
+    MemoCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+    MemoItem:
+      type: object
+      properties:
+        id:
+          type: string
+        body:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total_pages:
+          type: integer
+        total_count:
+          type: integer
+    MemoListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'


### PR DESCRIPTION
## Summary
- add `GET /api/memos` endpoint with pagination and optional tag filter
- support Link headers and logging of query params
- document API and provide Dockerfile

## Testing
- `go test ./...` *(fails: missing go.sum entries / unable to download modules)*
- `go vet ./...` *(fails: missing go.sum entries)*
- `golangci-lint run`
- `docker build . -t peconote:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942b839ee48326981311eb642b92cf