### PR TITLE
Add memo detail, update, and delete APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,57 @@ Response:
 ```json
 {
   "items": [{"id": "<uuid>", "body": "memo", "tags": ["tag"], "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"}],
-  "pagination": {"page": 2, "page_size": 10, "total_pages": 5, "total_count": 50}
+"pagination": {"page": 2, "page_size": 10, "total_pages": 5, "total_count": 50}
 }
 ```
+
+### Get Memo
+
+`GET /api/memos/{id}`
+
+Example:
+
+```bash
+curl http://localhost:8080/api/memos/<id>
+```
+
+Response:
+
+```json
+{"id": "<uuid>", "body": "memo", "tags": ["tag"], "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"}
+```
+
+### Update Memo
+
+`PUT /api/memos/{id}`
+
+Request body:
+
+```json
+{
+  "body": "updated text",
+  "tags": ["tag1", "tag2"]
+}
+```
+
+Example:
+
+```bash
+curl -X PUT http://localhost:8080/api/memos/<id> \
+  -H "Content-Type: application/json" \
+  -d '{"body":"updated","tags":["sample"]}'
+```
+
+Response: `204 No Content`
+
+### Delete Memo
+
+`DELETE /api/memos/{id}`
+
+Example:
+
+```bash
+curl -X DELETE http://localhost:8080/api/memos/<id>
+```
+
+Response: `204 No Content`

--- a/internal/adapter/handler/memo_dto.go
+++ b/internal/adapter/handler/memo_dto.go
@@ -11,6 +11,11 @@ type MemoCreateRequest struct {
 	Tags []string `json:"tags" binding:"max=10"`
 }
 
+type MemoUpdateRequest struct {
+	Body string   `json:"body" binding:"required,max=2000"`
+	Tags []string `json:"tags" binding:"max=10"`
+}
+
 type MemoCreateResponse struct {
 	ID string `json:"id"`
 }

--- a/internal/adapter/handler/memo_handler_e2e_test.go
+++ b/internal/adapter/handler/memo_handler_e2e_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,6 +51,36 @@ func (m *memoryMemoRepo) List(ctx context.Context, tag *string, limit, offset in
 		return []*domain.Memo{}, total, nil
 	}
 	return filtered[offset:end], total, nil
+}
+
+func (m *memoryMemoRepo) Get(ctx context.Context, id uuid.UUID) (*domain.Memo, error) {
+	for _, me := range m.memos {
+		if me.ID == id {
+			return me, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (m *memoryMemoRepo) Update(ctx context.Context, memo *domain.Memo) error {
+	for i, me := range m.memos {
+		if me.ID == memo.ID {
+			memo.CreatedAt = me.CreatedAt
+			m.memos[i] = memo
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (m *memoryMemoRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	for i, me := range m.memos {
+		if me.ID == id {
+			m.memos = append(m.memos[:i], m.memos[i+1:]...)
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func TestListMemos_E2E(t *testing.T) {

--- a/internal/adapter/repository/memo_pg.go
+++ b/internal/adapter/repository/memo_pg.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
@@ -65,4 +66,54 @@ LIMIT $2 OFFSET $3`
 		return nil, 0, err
 	}
 	return memos, total, nil
+}
+
+func (r *memoRepository) Get(ctx context.Context, id uuid.UUID) (*domain.Memo, error) {
+	type memoRow struct {
+		ID        uuid.UUID      `db:"id"`
+		Body      string         `db:"body"`
+		Tags      pq.StringArray `db:"tags"`
+		CreatedAt time.Time      `db:"created_at"`
+		UpdatedAt time.Time      `db:"updated_at"`
+	}
+	var row memoRow
+	query := `SELECT id, body, tags, created_at, updated_at FROM memo WHERE id = $1`
+	if err := r.db.GetContext(ctx, &row, query, id); err != nil {
+		return nil, err
+	}
+	return &domain.Memo{
+		ID:        row.ID,
+		Body:      row.Body,
+		Tags:      []string(row.Tags),
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}, nil
+}
+
+func (r *memoRepository) Update(ctx context.Context, m *domain.Memo) error {
+	query := `UPDATE memo SET body = :body, tags = :tags, updated_at = :updated_at WHERE id = :id`
+	res, err := r.db.NamedExecContext(ctx, query, map[string]interface{}{
+		"id":         m.ID,
+		"body":       m.Body,
+		"tags":       pq.StringArray(m.Tags),
+		"updated_at": m.UpdatedAt,
+	})
+	if err != nil {
+		return err
+	}
+	if cnt, err := res.RowsAffected(); err == nil && cnt == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (r *memoRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM memo WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if cnt, err := res.RowsAffected(); err == nil && cnt == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }

--- a/internal/domain/repository/memo_repository.go
+++ b/internal/domain/repository/memo_repository.go
@@ -3,10 +3,14 @@ package repository
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/peconote/peconote/internal/domain"
 )
 
 type MemoRepository interface {
 	Create(ctx context.Context, m *domain.Memo) error
 	List(ctx context.Context, tag *string, limit, offset int) ([]*domain.Memo, int, error)
+	Get(ctx context.Context, id uuid.UUID) (*domain.Memo, error)
+	Update(ctx context.Context, m *domain.Memo) error
+	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -30,6 +30,9 @@ func NewRouter(gormDB *gorm.DB, sqlxDB *sqlx.DB) *gin.Engine {
 
 	r.POST("/api/memos", memoHandler.CreateMemo)
 	r.GET("/api/memos", memoHandler.ListMemos)
+	r.GET("/api/memos/:id", memoHandler.GetMemo)
+	r.PUT("/api/memos/:id", memoHandler.UpdateMemo)
+	r.DELETE("/api/memos/:id", memoHandler.DeleteMemo)
 
 	return r
 }

--- a/internal/usecase/memo_interactor_test.go
+++ b/internal/usecase/memo_interactor_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -24,6 +25,19 @@ func (m *mockMemoRepository) Create(ctx context.Context, mem *domain.Memo) error
 
 func (m *mockMemoRepository) List(ctx context.Context, tag *string, limit, offset int) ([]*domain.Memo, int, error) {
 	return m.listItems, m.total, m.err
+}
+
+func (m *mockMemoRepository) Get(ctx context.Context, id uuid.UUID) (*domain.Memo, error) {
+	return m.memo, m.err
+}
+
+func (m *mockMemoRepository) Update(ctx context.Context, memo *domain.Memo) error {
+	m.memo = memo
+	return m.err
+}
+
+func (m *mockMemoRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.err
 }
 
 func TestCreateMemo_Success(t *testing.T) {
@@ -78,5 +92,40 @@ func TestListMemos_Validation(t *testing.T) {
 	longTag := "1234567890123456789012345678901"
 	if _, _, err := u.ListMemos(context.Background(), 1, 10, &longTag); !errors.Is(err, ErrInvalidMemoQuery) {
 		t.Fatalf("expected validation error")
+	}
+}
+
+func TestGetMemo_Success(t *testing.T) {
+	now := time.Now()
+	memo := &domain.Memo{ID: uuid.New(), Body: "b", CreatedAt: now, UpdatedAt: now}
+	repo := &mockMemoRepository{memo: memo}
+	u := NewMemoUsecase(repo)
+	got, err := u.GetMemo(context.Background(), memo.ID)
+	if err != nil || got.ID != memo.ID {
+		t.Fatalf("unexpected result")
+	}
+}
+
+func TestGetMemo_NotFound(t *testing.T) {
+	repo := &mockMemoRepository{err: sql.ErrNoRows}
+	u := NewMemoUsecase(repo)
+	if _, err := u.GetMemo(context.Background(), uuid.New()); !errors.Is(err, ErrMemoNotFound) {
+		t.Fatalf("expected not found")
+	}
+}
+
+func TestUpdateMemo_Validation(t *testing.T) {
+	repo := &mockMemoRepository{}
+	u := NewMemoUsecase(repo)
+	if err := u.UpdateMemo(context.Background(), uuid.New(), "", nil); !errors.Is(err, ErrInvalidMemo) {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestDeleteMemo_NotFound(t *testing.T) {
+	repo := &mockMemoRepository{err: sql.ErrNoRows}
+	u := NewMemoUsecase(repo)
+	if err := u.DeleteMemo(context.Background(), uuid.New()); !errors.Is(err, ErrMemoNotFound) {
+		t.Fatalf("expected not found")
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: PecoNote API
   version: 1.0.0
 paths:
-  /api/memos:
+    /api/memos:
     get:
       summary: List memos
       parameters:
@@ -40,16 +40,68 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MemoCreateRequest'
-      responses:
-        '201':
-          description: Created
+        responses:
+          '201':
+            description: Created
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/MemoCreateResponse'
+    /api/memos/{id}:
+      get:
+        summary: Get memo
+        parameters:
+          - in: path
+            name: id
+            required: true
+            schema:
+              type: string
+        responses:
+          '200':
+            description: OK
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/MemoItem'
+          '404':
+            description: Not Found
+      put:
+        summary: Update memo
+        parameters:
+          - in: path
+            name: id
+            required: true
+            schema:
+              type: string
+        requestBody:
+          required: true
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MemoCreateResponse'
-components:
-  schemas:
-    MemoCreateRequest:
+                $ref: '#/components/schemas/MemoUpdateRequest'
+        responses:
+          '204':
+            description: No Content
+          '400':
+            description: Bad Request
+          '404':
+            description: Not Found
+      delete:
+        summary: Delete memo
+        parameters:
+          - in: path
+            name: id
+            required: true
+            schema:
+              type: string
+        responses:
+          '204':
+            description: No Content
+          '404':
+            description: Not Found
+  components:
+    schemas:
+      MemoCreateRequest:
       type: object
       properties:
         body:
@@ -58,7 +110,17 @@ components:
           type: array
           items:
             type: string
-      required: [body]
+        required: [body]
+      MemoUpdateRequest:
+        type: object
+        properties:
+          body:
+            type: string
+          tags:
+            type: array
+            items:
+              type: string
+        required: [body]
     MemoCreateResponse:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- support retrieving a memo by ID, updating, and deleting
- expose new memo routes and handler logic for these operations
- document new endpoints in OpenAPI spec and README

## Testing
- `go test ./...` *(fails: missing go.sum entries for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68942fe346648326ad7faae7764cad32