### PR TITLE
chore: add initial react frontend skeleton

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+};

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,12 @@
+# PecoNote Web
+
+This directory contains the frontend SPA for PecoNote built with React, Vite and TypeScript.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Set `VITE_API_BASE` in `.env` to point to the backend API.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PecoNote</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "peconote-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^6.0.0",
+    "@tanstack/react-query": "^5.29.3",
+    "axios": "^1.6.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/react": "^14.2.2",
+    "@types/react": "^18.3.2",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.57.0",
+    "playwright": "^1.44.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.1.0",
+    "vitest": "^1.5.2"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,17 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import MemoListPage from './pages/MemoListPage';
+import MemoFormPage from './pages/MemoFormPage';
+import MemoDetailPage from './pages/MemoDetailPage';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/memos" replace />} />
+      <Route path="/memos" element={<MemoListPage />} />
+      <Route path="/memos/new" element={<MemoFormPage mode="create" />} />
+      <Route path="/memos/:id" element={<MemoDetailPage />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE,
+});
+
+client.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response?.status === 401) {
+      // handle unauthorized
+    }
+    if (err.response?.status && err.response.status >= 500) {
+      console.error('Server error', err);
+    }
+    return Promise.reject(err);
+  },
+);
+
+export default client;

--- a/web/src/hooks/useMemos.test.ts
+++ b/web/src/hooks/useMemos.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { useListMemos } from './useMemos';
+
+describe('useListMemos', () => {
+  it('should expose query key', () => {
+    const params = { page: 1 };
+    const result = useListMemos(params);
+    expect(result.queryKey).toEqual(['memos', params]);
+  });
+});

--- a/web/src/hooks/useMemos.ts
+++ b/web/src/hooks/useMemos.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import client from '../api/client';
+
+export interface Memo {
+  id: string;
+  body: string;
+  tags: string[];
+  createdAt: string;
+}
+
+export interface ListParams {
+  page?: number;
+  tag?: string;
+}
+
+export function useListMemos(params: ListParams) {
+  return useQuery({
+    queryKey: ['memos', params],
+    queryFn: async () => {
+      const { data } = await client.get('/memos', { params });
+      return data;
+    },
+  });
+}
+
+export function useCreateMemo() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (memo: Omit<Memo, 'id' | 'createdAt'>) => {
+      const { data } = await client.post('/memos', memo);
+      return data as Memo;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['memos'] });
+    },
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/web/src/pages/MemoDetailPage.tsx
+++ b/web/src/pages/MemoDetailPage.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import client from '../api/client';
+
+function MemoDetailPage() {
+  const { id } = useParams();
+  const { data } = useQuery({
+    queryKey: ['memo', id],
+    queryFn: async () => {
+      const { data } = await client.get(`/memos/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+
+  if (!data) return <div>Loading...</div>;
+  return (
+    <div>
+      <h1>Memo Detail</h1>
+      <p>{data.body}</p>
+    </div>
+  );
+}
+
+export default MemoDetailPage;

--- a/web/src/pages/MemoFormPage.tsx
+++ b/web/src/pages/MemoFormPage.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { useCreateMemo } from '../hooks/useMemos';
+
+interface Props {
+  mode: 'create' | 'edit';
+}
+
+function MemoFormPage({ mode }: Props) {
+  const [body, setBody] = useState('');
+  const mutation = useCreateMemo();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutation.mutate({ body, tags: [] });
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <textarea value={body} onChange={(e) => setBody(e.target.value)} />
+      <button type="submit">{mode === 'create' ? 'Create' : 'Update'}</button>
+    </form>
+  );
+}
+
+export default MemoFormPage;

--- a/web/src/pages/MemoListPage.tsx
+++ b/web/src/pages/MemoListPage.tsx
@@ -1,0 +1,18 @@
+import { useListMemos } from '../hooks/useMemos';
+
+function MemoListPage() {
+  const { data } = useListMemos({});
+
+  return (
+    <div>
+      <h1>Memos</h1>
+      <ul>
+        {data?.items?.map((m: any) => (
+          <li key={m.id}>{m.body}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default MemoListPage;

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface ToastState {
+  open: boolean;
+  message: string;
+}
+
+interface UIState {
+  toast: ToastState;
+  openToast: (message: string) => void;
+  closeToast: () => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  toast: { open: false, message: '' },
+  openToast: (message) => set({ toast: { open: true, message } }),
+  closeToast: () => set({ toast: { open: false, message: '' } }),
+}));

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React + Vite frontend skeleton under `web`
- add axios client, React Query provider, basic pages and hooks
- include ESLint, Prettier and Vitest configs

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894336a81a48326a6264049962a278d